### PR TITLE
Use HTTPS for Google Fonts API.

### DIFF
--- a/public/basket.html
+++ b/public/basket.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/category.html
+++ b/public/category.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/checkout1.html
+++ b/public/checkout1.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/checkout2.html
+++ b/public/checkout2.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/checkout3.html
+++ b/public/checkout3.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/checkout4.html
+++ b/public/checkout4.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/customer-account.html
+++ b/public/customer-account.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/customer-order.html
+++ b/public/customer-order.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/customer-orders.html
+++ b/public/customer-orders.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/customer-wishlist.html
+++ b/public/customer-wishlist.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/detail.html
+++ b/public/detail.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->

--- a/public/register.html
+++ b/public/register.html
@@ -17,7 +17,7 @@
 
     <meta name="keywords" content="">
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700,300,100'
           rel='stylesheet' type='text/css'>
 
     <!-- styles -->


### PR DESCRIPTION
Loading external resources should be done over HTTPS. When hosted on a HTTPS site, for example, Katacoda.com, Chrome displays an error and doesn't load the font. 