### PR TITLE
Handle errors explicitly in Catagolue image API forwarding.

### DIFF
--- a/api/catalogue/index.js
+++ b/api/catalogue/index.js
@@ -9,7 +9,9 @@
 
   app.get("/catalogue/images*", function (req, res, next) {
     var url = endpoints.catalogueUrl + req.url.toString();
-    request.get(url).pipe(res);
+    request.get(url)
+        .on('error', function(e) { next(e); })
+        .pipe(res);
   });
 
   app.get("/catalogue*", function (req, res, next) {


### PR DESCRIPTION
If errors are not handled, pipe() will throw an exception when get()
returns an error, crashing the nodejs process.

This fixes both https://github.com/microservices-demo/microservices-demo/issues/205 and https://github.com/microservices-demo/microservices-demo/issues/219