### PR TITLE
Cache Friendly Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM mhart/alpine-node:6.3
+ENV NODE_ENV "production"
+ENV PORT 8079
+EXPOSE 8079
 
 RUN mkdir -p /usr/src/app
 
 # Prepare app directory
 WORKDIR /usr/src/app
-COPY . /usr/src/app
+COPY package.json /usr/src/app/
 RUN npm install
 
-ENV NODE_ENV "production"
-ENV PORT 8079
-EXPOSE 8079
+COPY . /usr/src/app
 
 # Start the app
 CMD ["npm", "start"]


### PR DESCRIPTION
Copying the entire directory causes npm install to always require running, even if the dependencies haven't changed.