### PR TITLE
forgot to copy closing } after return order()

### DIFF
--- a/public/basket.html
+++ b/public/basket.html
@@ -408,7 +408,8 @@ _________________________________________________________ -->
                                 $('#orderButton').click(function(event) {
                                     if (orderPlaced == false) {
                                       orderPlaced = true;
-                                    return order();
+                                      return order();
+				    }
                                 });
                             }
                             $('#numItemsInCart').text('You currently have ' + numItemsInCart + ' item(s) in your cart.');


### PR DESCRIPTION
I accidentally forgot to copy over an extra line with single closing } after the code that I had added to avoid extra order created for shipping if checking out with more than 1 item in cart.  Sorry about that.  I noticed problems when I used new version with my changes.

This change fixes the issue.