### PR TITLE
Rename prom metric names to match default HTTP dashboards

### DIFF
--- a/api/metrics/index.js
+++ b/api/metrics/index.js
@@ -8,7 +8,7 @@
   const metric = {
     http: {
       requests: {
-        duration: new client.Histogram('request_duration_seconds', 'request duration in seconds', ['service', 'method', 'route', 'status_code']),
+        duration: new client.Histogram('http_request_duration_seconds', 'request duration in seconds', ['service', 'method', 'path', 'status_code']),
       }
     }
   }


### PR DESCRIPTION
Renames metrics so that Weave Cloud will be able to automagically generate an HTTP dashboard for this service.