### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,73 @@
+name: ci
+
+on:
+  push:
+    branches:
+    - "*"  # run for branches
+    tags:
+    - "*"  # run for tags
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GROUP: weaveworksdemos 
+      COMMIT: ${{ github.sha }}
+      REPO: front-end
+    steps:
+    - uses: actions/checkout@v2
+
+    #
+    #
+    # Set up  node
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '4.x'
+
+    #
+    #
+    # Install dependencies
+    - run: npm install
+
+    #
+    #
+    # Run node tests in docker image
+    - name: Test image
+      env:
+        DOCKER_BUILDKIT: 1
+      run: make test
+
+    #
+    #
+    # Build docker image for service
+    - name: Build docker image
+      uses: docker/build-push-action@v1
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+      with:
+        push: false
+        repository: ${{ env.GROUP }}/${{ env.REPO }}
+        tag_with_ref: true
+        tag_with_sha: true
+        tags: ${{ github.sha }}
+
+    #
+    #
+    # Run simple test against built container
+    - name: Test docker image
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+      env:
+        DOCKER_BUILDKIT: 1
+      run: ./test/container.sh
+
+    #
+    #
+    # Push to dockerhub
+    - name: Push to Docker Hub
+      uses: docker/build-push-action@v1
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: ${{ env.GROUP }}/${{ env.REPO }}
+        tag_with_ref: true
+        tag_with_sha: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
     # Build docker image for service
     - name: Build docker image
       uses: docker/build-push-action@v1
-      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       with:
         push: false
         repository: ${{ env.GROUP }}/${{ env.REPO }}
@@ -59,7 +58,6 @@ jobs:
     #
     # Run simple test against built container
     - name: Test docker image
-      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       env:
         DOCKER_BUILDKIT: 1
       run: ./test/container.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,11 @@ on:
     - "*"  # run for branches
     tags:
     - "*"  # run for tags
+  pull_request:
+    branches:
+    - "*"  # run for branches
+    tags:
+    - "*"  # run for tags
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
       uses: docker/build-push-action@v1
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASS }}
         repository: ${{ env.GROUP }}/${{ env.REPO }}
         tag_with_ref: true
         tag_with_sha: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMAGE=front-end
+DOCKER_IFLAG := $(if $(GITHUB_ACTIONS),"-i","-it")
 
 .PHONY: test coverage
 
@@ -46,7 +47,7 @@ test-image:
 test: test-image
 	@docker run              \
 		--rm                   \
-		-it                    \
+		$(DOCKER_IFLAG)                    \
 		-v $$PWD:/usr/src/app  \
 		$(IMAGE) /usr/local/bin/npm test
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/microservices-demo/front-end.svg?branch=master)](https://travis-ci.org/microservices-demo/front-end)
 [![](https://images.microbadger.com/badges/image/weaveworksdemos/front-end.svg)](http://microbadger.com/images/weaveworksdemos/front-end "Get your own image badge on microbadger.com")
+[![Actions Status](https://github.com/microservices-demo/front-end/workflows/ci/badge.svg)](https://github.com/microservices-demo/front-end/workflows/ci/badge.svg)
 
 
 Front-end app


### PR DESCRIPTION
This PR is to add a Github actions workflow to take advantage of the features offered by Github Actions and more closely integrate the code and CI.

This replicates all of the steps performed by Travis, some improvements could later be made if using Github Actions is accepted. 
The Slack notification hasnt been included in the GH actions workflow as it probably isnt required at the moment as we are still using Travis in parallel.