### PR TITLE
add denylist for redirection to avoid open redirects

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -51,10 +51,25 @@
     res.end();
   }
 
+  // list of invalid redirect paths
+  const denylist = ['//'];
+
+  const isInvalidRedirectPath = (redirectPath) => {
+    return denylist.some((denylistItem) => redirectPath.includes(denylistItem));
+  }
+
   /* Rewrites and redirects any url that doesn't end with a slash. */
   helpers.rewriteSlash = function(req, res, next) {
-   if(req.url.substr(-1) == '/' && req.url.length > 1)
-       res.redirect(301, req.url.slice(0, -1));
+    if(req.url.substr(-1) == '/' && req.url.length > 1){
+     var redirectPath = req.url.slice(0, -1);
+
+     if (isInvalidRedirectPath(redirectPath)) {
+       res.status(400).send('invalid URL to redirect to');
+     }else {
+       console.log("redirecting")
+       res.redirect(301, redirectPath );
+     }
+   }
    else
        next();
   }

--- a/test/helpers_test.js
+++ b/test/helpers_test.js
@@ -22,6 +22,36 @@
       app.use(bodyParser.json());
     });
 
+    describe("#redirectHandler", function() {
+      it("should return bad request if invalid redirection", function(done) {
+        app.use(function(req, res) {
+          helpers.rewriteSlash(req, res, done);
+        });
+
+        chai.request(app).
+        get("//category.html/").
+        end(function(err, res) {
+          expect(res).to.have.status(400);
+          done();
+        });
+      });
+
+      it("should redirect if valid redirection", function(done) {
+        app.use(function(req, res) {
+          helpers.rewriteSlash(req, res, done);
+        });
+
+        chai.request(app).
+        get("/category.html/").
+        end(function(err, res) {
+          expect(res).to.have.status(301);
+          done();
+        });
+      });
+
+    });
+
+
     describe("#errorHandler", function() {
       var message, code, error, res, resErr;
 


### PR DESCRIPTION
This PR addresses a potential open redirect attack by checking, before redirecting, whether the path to redirect to is valid.